### PR TITLE
switch to Bullseye

### DIFF
--- a/build/scripts/log.csx
+++ b/build/scripts/log.csx
@@ -1,5 +1,3 @@
-#load "nuget:simple-targets-csx, 6.0.0"
-
 public static class Log
 {
     private static readonly Dictionary<MessageType, Func<bool, string>> colors = new Dictionary<MessageType, Func<bool, string>>

--- a/build/scripts/runner.csx
+++ b/build/scripts/runner.csx
@@ -1,5 +1,4 @@
 #r "nuget:PowerArgs, 3.0.0"
-#load "nuget:simple-targets-csx, 6.0.0"
 
 using System;
 using System.Collections.Generic;
@@ -29,11 +28,6 @@ public static class Runner
         }
 
         return options;
-    }
-
-    public static void Run(BuildOptions options, IDictionary<string, SimpleTargets.Target> targets)
-    {
-        SimpleTargetsRunner.Run(new string[]{ options.Target }, targets, Console.Out);
     }
 
     public class BuildOptions


### PR DESCRIPTION
I'm deprecating simple-targets-csx in favour of [Bullseye](https://github.com/adamralph/bullseye) (it's a regular binary package instead of scripts, so can optionally be used in a [regular .NET project](https://github.com/xbehave/xbehave.net/blob/6d798877b4b891ce95ea8f2c5f9bee3d56a26bae/targets/Program.cs#L8)).